### PR TITLE
Fixed bug in block_writer.py

### DIFF
--- a/rltk/io/writer/block_writer.py
+++ b/rltk/io/writer/block_writer.py
@@ -31,7 +31,7 @@ class BlockWriter(Writer):
         Black list of indices. 
         """
         if getattr(self, '_blacklist'):
-            return self._blacklists
+            return self._blacklist
 
     def close(self):
         """

--- a/rltk/io/writer/block_writer.py
+++ b/rltk/io/writer/block_writer.py
@@ -31,8 +31,7 @@ class BlockWriter(Writer):
         Black list of indices. 
         """
         if getattr(self, '_blacklist'):
-            return self._blacklist
-        raise NotImplementedError
+            return self._blacklists
 
     def close(self):
         """


### PR DESCRIPTION
Removed the `NotImplementedError` exception raised in `get_blacklist()` method of `BlockWriter`. 